### PR TITLE
Fixes import statement and adds two commands

### DIFF
--- a/cmd/deletedeviceservice.go
+++ b/cmd/deletedeviceservice.go
@@ -1,0 +1,80 @@
+// Copyright © 2019 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+// deletedeviceserviceCmd represents the deletedeviceservice command
+var deletedeviceserviceCmd = &cobra.Command{
+	Use:   "deletedeviceservice",
+	Short: "Delete device service by name",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(args[0])
+
+		client := &http.Client{}
+
+		// Create request
+		req, err := http.NewRequest("DELETE", "http://localhost:48081/api/v1/deviceservice/name/"+args[0], nil)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		// Fetch Request
+		resp, err := client.Do(req)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		defer resp.Body.Close()
+
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		// Display Results
+		fmt.Println("response Status : ", resp.Status)
+		fmt.Println("response Headers : ", resp.Header)
+		fmt.Println("response Body : ", string(respBody))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deletedeviceserviceCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deletedeviceserviceCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deletedeviceserviceCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/devices.go
+++ b/cmd/devices.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	models "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/deviceservices.go
+++ b/cmd/deviceservices.go
@@ -1,0 +1,70 @@
+// Copyright © 2019 NAME HERE <EMAIL ADDRESS>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	models "github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/spf13/cobra"
+)
+
+type deviceServiceList struct {
+	rd []models.DeviceProfile
+}
+
+// deviceservicesCmd represents the deviceservices command
+var deviceservicesCmd = &cobra.Command{
+	Use:   "deviceservices",
+	Short: "Lists existing devices services",
+	Long:  `Return the list fo current device services.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		resp, err := http.Get("http://localhost:48081/api/v1/deviceservice")
+		if err != nil {
+			fmt.Println("An error occured. Is EdgeX running?")
+			fmt.Println(err)
+		}
+		defer resp.Body.Close()
+
+		data, _ := ioutil.ReadAll(resp.Body)
+
+		deviceServiceList1 := deviceServiceList{}
+
+		errjson := json.Unmarshal(data, &deviceServiceList1.rd)
+		if errjson != nil {
+			fmt.Println(errjson)
+		}
+		for i, device := range deviceServiceList1.rd {
+			fmt.Printf("%v\t%s\t%v\n", i, device.Name, device.Created)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deviceservicesCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deviceservicesCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deviceservicesCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/profiles.go
+++ b/cmd/profiles.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/edgexfoundry/edgex-go/pkg/models"
+	models "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/spf13/cobra"
 )
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "edgex-cli/cmd"
+import "github.com/edgexfoundry-holding/edgex-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Updated import statement that imported `models` from edgex-go. `models` is now imported from `go-mod-core-contracts`. Adds two commands to list and delete device services