### PR TITLE
implement git-style paging for list output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 edgex-cli
 edgex
 go.sum
+coverage.out
+
+.idea/
+

--- a/cmd/deviceservice/list/list.go
+++ b/cmd/deviceservice/list/list.go
@@ -17,14 +17,16 @@ package list
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 	"time"
 
-	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
-	"github.com/edgexfoundry-holding/edgex-cli/pkg/utils"
 	models "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/utils"
 )
 
 type deviceServiceList struct {
@@ -55,8 +57,9 @@ func NewCommand() *cobra.Command {
 				fmt.Println(errjson)
 			}
 
+			pw := viper.Get("writer").(io.WriteCloser)
 			w := new(tabwriter.Writer)
-			w.Init(os.Stdout, 0, 8, 1, '\t', 0)
+			w.Init(pw, 0, 8, 1, '\t', 0)
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t\n", "Service ID", "Service Name", "Created", "Operating State")
 			for _, device := range deviceServiceList1.rd {
 				tCreated := time.Unix(device.Created/1000, 0)

--- a/cmd/event/list/list.go
+++ b/cmd/event/list/list.go
@@ -17,16 +17,18 @@ package list
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"text/tabwriter"
 	"time"
 
-	"github.com/edgexfoundry-holding/edgex-cli/pkg/utils"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/utils"
 )
 
 // var rd []models.Device
@@ -79,8 +81,10 @@ func NewCommand() *cobra.Command {
 				fmt.Println(errjson)
 				return
 			}
+
+			pw := viper.Get("writer").(io.WriteCloser)
 			w := new(tabwriter.Writer)
-			w.Init(os.Stdout, 0, 8, 1, '\t', 0)
+			w.Init(pw, 0, 8, 1, '\t', 0)
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t\n", "Event ID", "Device", "Origin", "Created", "Modified")
 			for _, event := range eventList.rd {
 				tCreated := time.Unix(event.Created/1000, 0)

--- a/cmd/interval/list/list.go
+++ b/cmd/interval/list/list.go
@@ -17,13 +17,14 @@ package list
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"text/tabwriter"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type intervalList struct {
@@ -71,8 +72,10 @@ func listHandler(cmd *cobra.Command, args []string) {
 		fmt.Println(errjson)
 		return
 	}
+
+	pw := viper.Get("writer").(io.WriteCloser)
 	w := new(tabwriter.Writer)
-	w.Init(os.Stdout, 0, 8, 1, '\t', 0)
+	w.Init(pw, 0, 8, 1, '\t', 0)
 	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n", "Interval ID", "Name", "Start",
 		"End", "Frequency", "Cron", "RunOnce")
 	if len(args) > 0 {

--- a/cmd/profile/list/list.go
+++ b/cmd/profile/list/list.go
@@ -17,14 +17,16 @@ package list
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 	"time"
 
-	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
-	"github.com/edgexfoundry-holding/edgex-cli/pkg/utils"
 	models "github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/utils"
 )
 
 type deviceProfileList struct {
@@ -56,8 +58,10 @@ func NewCommand() *cobra.Command {
 			}
 
 			// TODO: Add commands and resources? They both are lists, so we need to think about how to display them
+
+			pw := viper.Get("writer").(io.WriteCloser)
 			w := new(tabwriter.Writer)
-			w.Init(os.Stdout, 0, 8, 1, '\t', 0)
+			w.Init(pw, 0, 8, 1, '\t', 0)
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t\n", "Profile ID", "Profile Name", "Created", "Modified", "Manufacturer", "Model")
 			for _, device := range deviceProfileList1.rd {
 				tCreated := time.Unix(device.Created/1000, 0)

--- a/pkg/pager/pager.go
+++ b/pkg/pager/pager.go
@@ -1,0 +1,109 @@
+// Copyright © 2019 Dell Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pager
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// Writer is used to write text to a terminal using the terminal's pager (less).
+// It implements the WriteCloser interface and should be closed when writing is finished.
+type Writer struct {
+	w io.WriteCloser
+	c chan struct{}
+	o sync.Once
+}
+
+// getPagerCommand inspects the PAGER environment variable for a pager command,
+// otherwise returns a reasonable default ("less -FRX")
+func getPagerCommand() (string, []string){
+	fromEnv := os.Getenv("PAGER")
+	if fromEnv == "" {
+		return "less", []string{"-FRX"}
+	}
+
+	split := strings.Split(fromEnv, " ")
+	return split[0], split[1:]
+}
+
+// NewWriter returns a new pager.Writer to be used to write
+// paged text to the terminal
+func NewWriter() (*Writer, error) {
+	name, args := getPagerCommand()
+	pager := exec.Command(name, args...)
+
+	// Create an os Pipe to allow clients to write into our pager
+	r, w, err := os.Pipe()
+	if err != nil {
+		fmt.Println(err.Error())
+		return nil, err
+	}
+
+	pager.Stdin = r
+	pager.Stdout = os.Stdout
+	pager.Stderr = os.Stderr
+
+	c := make(chan struct{})
+
+	writer := Writer{
+		w: w,
+		c: c,
+		o: sync.Once{},
+	}
+
+	// run pager in goroutine
+	go func() {
+		defer func(){
+			close(c)
+			// Defer a close on the writer so potentially blocked clients will
+			// become unblocked.  w has potentially already been closed by the
+			// Writer's Close method, but without this Close call (or a ReadAll call,
+			// alternatively) writers can be blocked forever.
+			_ = writer.close()
+		}()
+		_ = pager.Run()
+	}()
+
+	return &writer, nil
+}
+
+// Write writes a slice of bytes to the Writer
+func (w *Writer) Write(p []byte) (n int, err error) {
+	return w.w.Write(p)
+}
+
+// close ensures the Close() method of our pipe is called only once, regardless of whether
+// the client calls Close first or the pager terminates first.
+func (w *Writer) close() error {
+	var err error
+	w.o.Do(func() {
+		err = w.w.Close()
+	})
+
+	return err
+}
+
+// Close is potentially a blocking call, as it will wait
+// until the pager command terminates before returning.
+func (w *Writer) Close() error {
+	err := w.close()
+	<-w.c
+	return err
+}


### PR DESCRIPTION
Implements paging (a la 'less' or 'more') for the output of the list
commands.  The implementation is based on the implementation of
paging in the git cli.  The flag --no-pager is added to prevent
any paging, and the pager command defaults to less -FRX, unless
specified by the $PAGER env variable (both match the git implementation).

Signed-off-by: Daniel Harms <jdharms@gmail.com>