### PR TITLE
Adds verbose flag and flags refactoring.

### DIFF
--- a/cmd/db/purge/purge.go
+++ b/cmd/db/purge/purge.go
@@ -67,7 +67,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.Device
 			}
 
-			deviceData, err := client.GetAllItems("device", "48081", verbose)
+			deviceData, err := client.GetAllItems("device", "48081")
 
 			if err != nil {
 				fmt.Println(err)
@@ -101,7 +101,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.DeviceReport
 			}
 
-			deviceReportData, err := client.GetAllItems("devicereport", "48081", verbose)
+			deviceReportData, err := client.GetAllItems("devicereport", "48081")
 
 			if err != nil {
 				fmt.Println(err)
@@ -134,7 +134,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.DeviceService
 			}
 
-			deviceServiceData, err := client.GetAllItems("deviceservice", "48081", verbose)
+			deviceServiceData, err := client.GetAllItems("deviceservice", "48081")
 
 			if err != nil {
 				fmt.Println(err)
@@ -167,7 +167,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.DeviceProfile
 			}
 
-			DeviceProfileData, err := client.GetAllItems("deviceprofile", "48081", verbose)
+			DeviceProfileData, err := client.GetAllItems("deviceprofile", "48081")
 
 			if err != nil {
 				fmt.Println(err)
@@ -203,7 +203,7 @@ database. Currently, it only cleans up core-metadata.
 
 			// Calling GetAllItems function, which
 			// makes API call to get all items of given typ
-			data, err := client.GetAllItems("addressable", "48081", verbose)
+			data, err := client.GetAllItems("addressable", "48081")
 
 			if err != nil {
 				fmt.Println(err)
@@ -240,7 +240,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.ProvisionWatcher
 			}
 
-			provisionWatcherData, err := client.GetAllItems("provisionwatcher", "48081", verbose)
+			provisionWatcherData, err := client.GetAllItems("provisionwatcher", "48081")
 
 			if err != nil {
 				fmt.Println(err)
@@ -283,7 +283,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.Reading
 			}
 
-			readingData, err := client.GetAllItems("reading", "48080", verbose)
+			readingData, err := client.GetAllItems("reading", "48080")
 
 			if err != nil {
 				fmt.Println(err)
@@ -320,7 +320,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.ValueDescriptor
 			}
 
-			valueDescriptorData, err := client.GetAllItems("valuedescriptor", "48080", verbose)
+			valueDescriptorData, err := client.GetAllItems("valuedescriptor", "48080")
 
 			if err != nil {
 				fmt.Println(err)
@@ -367,7 +367,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.Interval
 			}
 
-			intervalData, err := client.GetAllItems("interval", "48085", verbose)
+			intervalData, err := client.GetAllItems("interval", "48085")
 
 			if err != nil {
 				fmt.Println(err)
@@ -403,7 +403,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.IntervalAction
 			}
 
-			intervalactionData, err := client.GetAllItems("intervalaction", "48085", verbose)
+			intervalactionData, err := client.GetAllItems("intervalaction", "48085")
 
 			if err != nil {
 				fmt.Println(err)
@@ -446,7 +446,7 @@ database. Currently, it only cleans up core-metadata.
 				list []models.Registration
 			}
 
-			registrationData, err := client.GetAllItems("registration", "48071", verbose)
+			registrationData, err := client.GetAllItems("registration", "48071")
 
 			if err != nil {
 				fmt.Println(err)

--- a/cmd/device/list/list.go
+++ b/cmd/device/list/list.go
@@ -39,9 +39,11 @@ func NewCommand() *cobra.Command {
 		Long:  `Return all device services sorted by id.`,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			verbose, _ := cmd.Flags().GetBool("verbose")
+			data, err := client.GetAllItems("device", "48081")
 
-			data, err := client.GetAllItems("device", "48081", verbose)
+			if data == nil {
+				return
+			}
 
 			if err != nil {
 				fmt.Println(err)

--- a/cmd/device/rm/rm.go
+++ b/cmd/device/rm/rm.go
@@ -51,7 +51,7 @@ You can use: '$ edgex device list' to find a device's name and ID.`,
 			if string(respBody) == "true" {
 				fmt.Printf("Removed: %s\n", deviceID)
 			} else {
-				fmt.Printf("Error: Remove Unsuccessful!\n")
+				fmt.Printf("Error: Remove Unsuccessful: %s\n", string(respBody))
 			}
 		},
 	}

--- a/cmd/deviceservice/list/list.go
+++ b/cmd/deviceservice/list/list.go
@@ -41,9 +41,7 @@ func NewCommand() *cobra.Command {
 		Long:  `Return the list fo current device services.`,
 		Run: func(cmd *cobra.Command, args []string) {
 
-			verbose, _ := cmd.Flags().GetBool("verbose")
-
-			data, err := client.GetAllItems("deviceservice", "48081", verbose)
+			data, err := client.GetAllItems("deviceservice", "48081")
 
 			if err != nil {
 				fmt.Println(err)

--- a/cmd/deviceservice/rm/rm.go
+++ b/cmd/deviceservice/rm/rm.go
@@ -50,7 +50,7 @@ func NewCommand() *cobra.Command {
 			if string(respBody) == "true" {
 				fmt.Printf("Removed: %s\n", deviceID)
 			} else {
-				fmt.Printf("Remove Unsuccessful!\n")
+				fmt.Printf("Remove Unsuccessful: %s\n", string(respBody))
 			}
 		},
 	}

--- a/cmd/profile/list/list.go
+++ b/cmd/profile/list/list.go
@@ -40,10 +40,7 @@ func NewCommand() *cobra.Command {
 		Short: "Returns a list of device profiles",
 		Long:  `Returns the list of device profiles currently in the core-metadata database.`,
 		Run: func(cmd *cobra.Command, args []string) {
-
-			verbose, _ := cmd.Flags().GetBool("verbose")
-
-			data, err := client.GetAllItems("deviceprofile", "48081", verbose)
+			data, err := client.GetAllItems("deviceprofile", "48081")
 
 			if err != nil {
 				fmt.Println(err)

--- a/cmd/profile/rm/rm.go
+++ b/cmd/profile/rm/rm.go
@@ -49,7 +49,7 @@ func NewCommand() *cobra.Command {
 			if string(respBody) == "true" {
 				fmt.Printf("Removed: %s\n", deviceID)
 			} else {
-				fmt.Printf("Remove Unsuccessful!\n")
+				fmt.Printf("Remove Unsuccessful: %s\n", respBody)
 			}
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,24 @@ import (
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// set flags
 			noPager, err := cmd.Flags().GetBool("no-pager")
+
+			verbose, _ := cmd.Flags().GetBool("verbose")
+			if err != nil {
+				fmt.Println("couldn't get verbose flag")
+			}
+			viper.Set("verbose", verbose)
+			if verbose {
+				noPager = true
+			}
+
+			url, _ := cmd.Flags().GetBool("url")
+			if err != nil {
+				fmt.Println("couldn't get url flag")
+			}
+			viper.Set("url", url)
+
 			if err != nil {
 				fmt.Println("couldn't get no-pager flag")
 			}
@@ -54,6 +71,7 @@ func NewCommand() *cobra.Command {
 					viper.Set("writerShouldClose", true) // This flag prevents us from calling close on stdout
 				}
 			}
+
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
 			shouldClose := viper.GetBool("writerShouldClose")
@@ -97,8 +115,12 @@ https://www.edgexfoundry.org/
 
 	// global flags
 	Verbose := false
+	URL := false
 	NoPager := false
-	cmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Print URL(s) used by the entered command.")
+
+	// get flags values
+	cmd.PersistentFlags().BoolVarP(&URL, "url", "u", false, "Print URL(s) used by the entered command.")
+	cmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Print entire HTTP response.")
 	cmd.PersistentFlags().BoolVarP(&NoPager, "no-pager", "", false, "Do not pipe output into a pager.")
 
 	return cmd


### PR DESCRIPTION
Adds verbose flag that prints the http response's
header and body. Also removes flag logic from individual commands.
The flags are read and assigned to viper in PersistentPreRun and
read in client.

Signed-off-by: Alex Courouble <acourouble@vmware.com>