### PR TITLE
[wip] Leverage clients provided by go-mod-core-contracts

### DIFF
--- a/cmd/addressable/list/list.go
+++ b/cmd/addressable/list/list.go
@@ -17,10 +17,11 @@ package list
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/edgexfoundry-holding/edgex-cli/config"
-	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
 	"io"
 	"text/tabwriter"
+
+	"github.com/edgexfoundry-holding/edgex-cli/config"
+	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/spf13/cobra"
@@ -40,7 +41,7 @@ func NewCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 
 			data, err := client.GetAllItems(
-				config.Conf.MetadataService.AddressableList,
+				"addressable",
 				config.Conf.MetadataService.Port)
 
 			if data == nil {

--- a/cmd/addressable/list/list.go
+++ b/cmd/addressable/list/list.go
@@ -17,15 +17,14 @@ package list
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/edgexfoundry-holding/edgex-cli/config"
+	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
 	"io"
 	"text/tabwriter"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
-	"github.com/edgexfoundry-holding/edgex-cli/config"
-	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
 )
 
 type addressableList struct {

--- a/cmd/db/purge/purge.go
+++ b/cmd/db/purge/purge.go
@@ -137,8 +137,8 @@ func purge() {
 	for _, object := range devices.list {
 		// call delete function here
 		_, err = client.DeleteItem(object.Id,
-			config.Conf.MetadataService.DeviceServiceByIDRoute,
-			config.Conf.MetadataService.DeviceServiceBySlugNameRoute,
+			"device/id/",
+			"device/name/",
 			config.Conf.MetadataService.Port)
 
 		if err != nil {
@@ -147,43 +147,6 @@ func purge() {
 		}
 	}
 	fmt.Println("Removed ", numberDevices, " devices.")
-
-	//////////////////////////////////////////////////////
-	// DR
-	//////////////////////////////////////////////////////
-
-	type deviceReportList struct {
-		list []models.DeviceReport
-	}
-
-	deviceReportData, err := client.GetAllItems("devicereport", "48081")
-
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	devicereports := deviceReportList{}
-
-	devicereporterrjson := json.Unmarshal(deviceReportData, &devicereports.list)
-	if devicereporterrjson != nil {
-		fmt.Println(devicereporterrjson)
-	}
-
-	numberDRs := len(devicereports.list)
-	for _, object := range devicereports.list {
-		// call delete function here
-		_, err = client.DeleteItem(object.Id,
-			config.Conf.MetadataService.DeviceServiceByIDRoute,
-			config.Conf.MetadataService.DeviceServiceBySlugNameRoute,
-			config.Conf.MetadataService.Port)
-
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-	}
-	fmt.Println("Removed ", numberDRs, " device reports.")
 
 	//////////////////////////////////////////////////////
 	// DS
@@ -209,8 +172,8 @@ func purge() {
 	for _, object := range deviceservices.list {
 		// call delete function here
 		_, err = client.DeleteItem(object.Id,
-			config.Conf.MetadataService.DeviceServiceByIDRoute,
-			config.Conf.MetadataService.DeviceServiceBySlugNameRoute,
+			"deviceservice/id/",
+			"deviceservice/name/",
 			config.Conf.MetadataService.Port)
 
 		if err != nil {
@@ -246,8 +209,8 @@ func purge() {
 	for _, object := range deviceprofiles.list {
 		// call delete function here
 		_, err = client.DeleteItem(object.Id,
-			config.Conf.MetadataService.DeviceProfileByIDRoute,
-			config.Conf.MetadataService.DeviceProfileBySlugNameRoute,
+			"deviceprofile/id/",
+			"deviceprofile/name/",
 			config.Conf.MetadataService.Port)
 
 		if err != nil {
@@ -288,8 +251,8 @@ func purge() {
 	for _, addr := range list.list {
 		// call delete function here
 		_, err = client.DeleteItem(addr.Id,
-			config.Conf.MetadataService.DeviceServiceByIDRoute,
-			config.Conf.MetadataService.DeviceServiceBySlugNameRoute,
+			"addressable/id/",
+			"addressable/name/",
 			config.Conf.MetadataService.Port)
 
 		if err != nil {
@@ -297,45 +260,7 @@ func purge() {
 			return
 		}
 	}
-	fmt.Println("Removed ", numberItems, " device provision watchers.")
-
-	//////////////////////////////////////////////////////
-	// Provision watchers
-	//////////////////////////////////////////////////////
-
-	type provisionWatcherList struct {
-		list []models.ProvisionWatcher
-	}
-
-	provisionWatcherData, err := client.GetAllItems("provisionwatcher", "48081")
-
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	provisionwatchers := provisionWatcherList{}
-
-	provisionwatchererrjson := json.Unmarshal(provisionWatcherData, &provisionwatchers.list)
-	if provisionwatchererrjson != nil {
-		fmt.Println(provisionwatchererrjson)
-	}
-
-	numberPRs := len(provisionwatchers.list)
-	for _, object := range provisionwatchers.list {
-		// call delete function here
-		_, err = client.DeleteItem(object.Id,
-			config.Conf.MetadataService.DeviceServiceByIDRoute,
-			config.Conf.MetadataService.DeviceServiceBySlugNameRoute,
-			config.Conf.MetadataService.Port)
-
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-	}
-
-	fmt.Println("Removed ", numberPRs, " device provision watchers.")
+	fmt.Println("Removed ", numberItems, " addressables.")
 
 	// CORE-DATA:
 	fmt.Println("* core-data")
@@ -373,7 +298,7 @@ func purge() {
 		// call delete function here
 
 		_, err = client.DeleteItem(object.Id,
-			config.Conf.DataService.ReadingByIDRoute,
+			"reading/id/",
 			"",
 			config.Conf.DataService.Port)
 
@@ -412,8 +337,8 @@ func purge() {
 
 		// call delete function here
 		_, err = client.DeleteItem(object.Id,
-			config.Conf.DataService.VDescriptorByIDRoute,
-			config.Conf.DataService.VDescriptorByNameRoute,
+			"valuedescriptor/id/",
+			"valuedescriptor/name/",
 			config.Conf.DataService.Port)
 
 		if err != nil {
@@ -462,8 +387,8 @@ func purge() {
 
 		// call delete function here
 		_, err = client.DeleteItem(object.ID,
-			config.Conf.SchedulerService.IntervalByIDRoute,
-			config.Conf.SchedulerService.IntervalByNameSlugRoute,
+			"interval",
+			"interval/name/",
 			config.Conf.SchedulerService.Port)
 
 		if err != nil {
@@ -500,8 +425,8 @@ func purge() {
 
 		// call delete function here
 		_, err = client.DeleteItem(object.ID,
-			config.Conf.SchedulerService.IntervalActionByIDRoute,
-			config.Conf.SchedulerService.IntervalActionByNameSlugRoute,
+			"intervalaction/",
+			"intervalaction/name/",
 			config.Conf.SchedulerService.Port)
 
 		if err != nil {

--- a/cmd/db/purge/purge.go
+++ b/cmd/db/purge/purge.go
@@ -518,44 +518,44 @@ func purge() {
 	fmt.Println("* Notifications")
 	removeNotifications()
 
-	//////////////////////////////////////////////////////
-	// exportclient
-	//////////////////////////////////////////////////////
-
-	type registrationList struct {
-		list []models.Registration
-	}
-
-	registrationData, err := client.GetAllItems("registration", "48071")
-
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
-	registrations := registrationList{}
-
-	registrationerrjson := json.Unmarshal(registrationData, &registrations.list)
-	if registrationerrjson != nil {
-		fmt.Println(registrationerrjson)
-	}
-
-	numberRegs := len(registrations.list)
-	for _, object := range registrations.list {
-
-		// call delete function here
-		_, err = client.DeleteItem(object.ID,
-			config.Conf.ExportService.RegistrationByIDRoute,
-			config.Conf.ExportService.RegistrationByNameRoute,
-			config.Conf.ExportService.Port)
-
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-	}
-
-	fmt.Println("Removed ", numberRegs, " registrations.")
+	////////////////////////////////////////////////////////
+	//// exportclient
+	////////////////////////////////////////////////////////
+	//
+	//type registrationList struct {
+	//	list []models.Registration
+	//}
+	//
+	//registrationData, err := client.GetAllItems("registration", "48071")
+	//
+	//if err != nil {
+	//	fmt.Println(err)
+	//	return
+	//}
+	//
+	//registrations := registrationList{}
+	//
+	//registrationerrjson := json.Unmarshal(registrationData, &registrations.list)
+	//if registrationerrjson != nil {
+	//	fmt.Println(registrationerrjson)
+	//}
+	//
+	//numberRegs := len(registrations.list)
+	//for _, object := range registrations.list {
+	//
+	//	// call delete function here
+	//	_, err = client.DeleteItem(object.ID,
+	//		config.Conf.ExportService.RegistrationByIDRoute,
+	//		config.Conf.ExportService.RegistrationByNameRoute,
+	//		config.Conf.ExportService.Port)
+	//
+	//	if err != nil {
+	//		fmt.Println(err)
+	//		return
+	//	}
+	//}
+	//
+	//fmt.Println("Removed ", numberRegs, " registrations.")
 }
 
 func removeEventsAndReadings() {

--- a/cmd/deviceservice/rm/rm.go
+++ b/cmd/deviceservice/rm/rm.go
@@ -17,7 +17,6 @@ package rm
 import (
 	"fmt"
 
-	"github.com/edgexfoundry-holding/edgex-cli/config"
 	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
 	"github.com/spf13/cobra"
 )
@@ -38,9 +37,9 @@ func NewCommand() *cobra.Command {
 
 			deviceID := args[0]
 			respBody, err := client.DeleteItem(deviceID,
-				config.Conf.MetadataService.DeviceServiceByIDRoute,
-				config.Conf.MetadataService.DeviceServiceBySlugNameRoute,
-				config.Conf.MetadataService.Port)
+				"deviceservice/id/",
+				"deviceservice/name/",
+				"48081")
 
 			if err != nil {
 				fmt.Println(err)

--- a/cmd/event/list/list.go
+++ b/cmd/event/list/list.go
@@ -15,12 +15,8 @@
 package list
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/edgexfoundry-holding/edgex-cli/config"
-	"github.com/edgexfoundry-holding/edgex-cli/pkg/urlclient"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -33,8 +29,6 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/edgexfoundry-holding/edgex-cli/pkg/utils"
-
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 )
 
 // var rd []models.Device
@@ -52,24 +46,6 @@ func NewCommand() *cobra.Command {
 		Long:  `Return all device services sorted by id.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-
-
-			//ctx, _ := context.WithCancel(context.Background())
-			//
-			//url := config.Conf.DataService.Protocol + "://" +
-			//	config.Conf.DataService.Host + ":" +
-			//	config.Conf.DataService.Port
-			//
-			//dc := coredata.NewEventClient(
-			//	urlclient.New(
-			//		ctx,
-			//		clients.CoreDataServiceKey,
-			//		clients.ApiEventRoute,
-			//		15000,
-			//		url + clients.ApiEventRoute))
-			//
-			//events, err := dc.Events(ctx)
-
 
 			var url string
 			if len(args) > 0 {

--- a/cmd/event/list/list.go
+++ b/cmd/event/list/list.go
@@ -15,8 +15,12 @@
 package list
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/edgexfoundry-holding/edgex-cli/config"
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/urlclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -29,6 +33,8 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/edgexfoundry-holding/edgex-cli/pkg/utils"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 )
 
 // var rd []models.Device
@@ -46,6 +52,24 @@ func NewCommand() *cobra.Command {
 		Long:  `Return all device services sorted by id.`,
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+
+
+			//ctx, _ := context.WithCancel(context.Background())
+			//
+			//url := config.Conf.DataService.Protocol + "://" +
+			//	config.Conf.DataService.Host + ":" +
+			//	config.Conf.DataService.Port
+			//
+			//dc := coredata.NewEventClient(
+			//	urlclient.New(
+			//		ctx,
+			//		clients.CoreDataServiceKey,
+			//		clients.ApiEventRoute,
+			//		15000,
+			//		url + clients.ApiEventRoute))
+			//
+			//events, err := dc.Events(ctx)
+
 
 			var url string
 			if len(args) > 0 {

--- a/cmd/event/rm/rm.go
+++ b/cmd/event/rm/rm.go
@@ -15,10 +15,13 @@
 package rm
 
 import (
+	"context"
 	"fmt"
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/urlclient"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 
 	"github.com/edgexfoundry-holding/edgex-cli/config"
-	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
 	"github.com/spf13/cobra"
 )
 
@@ -37,24 +40,50 @@ func NewCommand() *cobra.Command {
 			}
 
 			deviceID := args[0]
-			respBody, err := client.DeleteItemByName(deviceID,
-				config.Conf.DataService.DeleteEventByDeviceIDRoute,
-				config.Conf.DataService.Port)
+
+
+			ctx, _ := context.WithCancel(context.Background())
+
+			url := config.Conf.DataService.Protocol + "://" +
+				config.Conf.DataService.Host + ":" +
+				config.Conf.DataService.Port
+
+			dc := coredata.NewEventClient(
+				urlclient.New(
+					ctx,
+					clients.CoreDataServiceKey,
+					clients.ApiEventRoute,
+					15000,
+					url + clients.ApiEventRoute))
+
+			err := dc.DeleteForDevice(ctx, deviceID)
 
 			if err != nil {
 				fmt.Println(err)
 				return
 			}
 
-			// Display Results
-			if string(respBody) == "0" {
-				fmt.Printf("Removed events for device: %s\n", deviceID)
-			} else {
-				fmt.Printf("Remove Unsuccessful!\n")
-			}
-
 			fmt.Println("Removing events for device:")
 			fmt.Println(deviceID)
+
+			//respBody, err := client.DeleteItemByName(deviceID,
+			//	config.Conf.DataService.DeleteEventByDeviceIDRoute,
+			//	config.Conf.DataService.Port)
+			//
+			//if err != nil {
+			//	fmt.Println(err)
+			//	return
+			//}
+			//
+			//// Display Results
+			//if string(respBody) == "0" {
+			//	fmt.Printf("Removed events for device: %s\n", deviceID)
+			//} else {
+			//	fmt.Printf("Remove Unsuccessful!\n")
+			//}
+			//
+			//fmt.Println("Removing events for device:")
+			//fmt.Println(deviceID)
 		},
 	}
 	return cmd

--- a/cmd/notification/rm/rm.go
+++ b/cmd/notification/rm/rm.go
@@ -17,7 +17,6 @@ package rm
 import (
 	"fmt"
 
-	"github.com/edgexfoundry-holding/edgex-cli/config"
 	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
 	"github.com/spf13/cobra"
 )
@@ -35,14 +34,14 @@ func removeNotificationHandler(cmd *cobra.Command, args []string) {
 
 	var url string
 	if byAge {
-		url = config.Conf.NotificationService.NotificationByAgeRoute
+		url = "notification/age/"
 	} else {
-		url = config.Conf.NotificationService.NotificationByNameSlugRoute
+		url = "notification/slug/"
 	}
 
 	respBody, err := client.DeleteItemByName(args[0],
 		url,
-		config.Conf.MetadataService.Port)
+		"48060")
 
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/subscription/list/list.go
+++ b/cmd/subscription/list/list.go
@@ -41,7 +41,7 @@ func NewCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 
 			data, err := client.GetAllItems(
-				config.Conf.NotificationService.SubscriptionByIDRoute,
+				"subscription",
 				config.Conf.NotificationService.Port)
 
 			if data == nil {

--- a/cmd/subscription/rm/rm.go
+++ b/cmd/subscription/rm/rm.go
@@ -17,7 +17,6 @@ package rm
 import (
 	"fmt"
 
-	"github.com/edgexfoundry-holding/edgex-cli/config"
 	client "github.com/edgexfoundry-holding/edgex-cli/pkg"
 	"github.com/spf13/cobra"
 )
@@ -36,9 +35,9 @@ func removeSubscriptionHandler(cmd *cobra.Command, args []string) {
 	subscriptionlID := args[0]
 
 	respBody, err := client.DeleteItem(subscriptionlID,
-		config.Conf.NotificationService.SubscriptionByIDRoute,
-		config.Conf.NotificationService.SubscriptionByNameSlugRoute,
-		config.Conf.NotificationService.Port)
+		"subscription",
+		"subscription/name/",
+		"48060")
 
 	if err != nil {
 		fmt.Println(err)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -41,67 +41,61 @@ type Security struct {
 	Token   string
 }
 
-//type ClientInfo struct {
-//	Protocol string
-//	Host string
-//	Port int
-//}
-
 type SchedulerService struct {
-	Port		string
-	Host		string
-	Protocol	string
+	Port     string
+	Host     string
+	Protocol string
 }
 
 type NotificationService struct {
-	Port		string
-	Host		string
-	Protocol	string
+	Port     string
+	Host     string
+	Protocol string
 }
 
 type MetadataService struct {
-	Port		string
-	Host		string
-	Protocol	string
+	Port     string
+	Host     string
+	Protocol string
 }
 
 type DataService struct {
-	Port		string
-	Host		string
-	Protocol	string
+	Port     string
+	Host     string
+	Protocol string
 }
 
 type ExportService struct {
-	Port		string
-	Host		string
-	Protocol	string
+	Port     string
+	Host     string
+	Protocol string
 }
 
 var Conf Configuration = Configuration{
 	SchedulerService: SchedulerService{
-		Port:		"48085",
-		Host:		"localhost",
-		Protocol:	"http",
+		Port:     "48085",
+		Host:     "localhost",
+		Protocol: "http",
 	},
 	NotificationService: NotificationService{
-		Port:		"48060",
-		Host:		"localhost",
-		Protocol:	"http",
+		Port:     "48060",
+		Host:     "localhost",
+		Protocol: "http",
 	},
 	MetadataService: MetadataService{
-		Port:		"48081",
-		Host:		"localhost",
-		Protocol:	"http",
+		Port:     "48081",
+		Host:     "localhost",
+		Protocol: "http",
 	},
 	DataService: DataService{
-		Port:		"48080",
-		Host:		"localhost",
-		Protocol:	"http",
+		Port:     "48080",
+		Host:     "localhost",
+		Protocol: "http",
 	},
 	ExportService: ExportService{
-		Port:		"48071",
-		Host:		"localhost",
-		Protocol:	"http",
+		Port:     "48071",
+		Host:     "localhost",
+		Protocol: "http",
 	},
 }
 

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -26,8 +26,8 @@ var AppFs = afero.NewOsFs()
 
 // Configuration struct will use this to write config file eventually
 type Configuration struct {
-	Host string
 	Security
+	//Client 				map[string]ClientInfo
 	DataService         DataService
 	MetadataService     MetadataService
 	SchedulerService    SchedulerService
@@ -41,84 +41,67 @@ type Security struct {
 	Token   string
 }
 
+//type ClientInfo struct {
+//	Protocol string
+//	Host string
+//	Port int
+//}
+
 type SchedulerService struct {
-	Port                          string
-	IntervalByIDRoute             string
-	IntervalByNameSlugRoute       string
-	IntervalActionByIDRoute       string
-	IntervalActionByNameSlugRoute string
+	Port		string
+	Host		string
+	Protocol	string
 }
 
 type NotificationService struct {
-	Port                        string
-	SubscriptionByIDRoute       string
-	SubscriptionByNameSlugRoute string
-	NotificationByAgeRoute      string
-	NotificationByNameSlugRoute string
+	Port		string
+	Host		string
+	Protocol	string
 }
 
 type MetadataService struct {
-	Port                         string
-	DeviceServiceByIDRoute       string
-	DeviceServiceBySlugNameRoute string
-	DeviceByIDRoute              string
-	DeviceBySlugNameRoute        string
-	DeviceProfileByIDRoute       string
-	DeviceProfileBySlugNameRoute string
-	AddressableList              string
+	Port		string
+	Host		string
+	Protocol	string
 }
 
 type DataService struct {
-	Port                       string
-	ReadingByIDRoute           string
-	VDescriptorByIDRoute       string
-	VDescriptorByNameRoute     string
-	DeleteEventByDeviceIDRoute string
+	Port		string
+	Host		string
+	Protocol	string
 }
 
 type ExportService struct {
-	Port                    string
-	RegistrationByIDRoute   string
-	RegistrationByNameRoute string
+	Port		string
+	Host		string
+	Protocol	string
 }
 
 var Conf Configuration = Configuration{
-	Host: "localhost",
 	SchedulerService: SchedulerService{
-		Port:                          "48085",
-		IntervalByIDRoute:             "interval",
-		IntervalByNameSlugRoute:       "interval/name/",
-		IntervalActionByIDRoute:       "intervalaction/",
-		IntervalActionByNameSlugRoute: "intervalaction/name/",
+		Port:		"48085",
+		Host:		"localhost",
+		Protocol:	"http",
 	},
 	NotificationService: NotificationService{
-		Port:                        "48060",
-		SubscriptionByIDRoute:       "subscription",
-		SubscriptionByNameSlugRoute: "subscription/name/",
-		NotificationByAgeRoute:      "notification/age/",
-		NotificationByNameSlugRoute: "notification/slug/",
+		Port:		"48060",
+		Host:		"localhost",
+		Protocol:	"http",
 	},
 	MetadataService: MetadataService{
-		Port:                         "48081",
-		DeviceServiceByIDRoute:       "deviceservice/id/",
-		DeviceServiceBySlugNameRoute: "deviceservice/name/",
-		DeviceByIDRoute:              "device/id/",
-		DeviceBySlugNameRoute:        "device/name/",
-		DeviceProfileByIDRoute:       "deviceprofile/id/",
-		DeviceProfileBySlugNameRoute: "deviceprofile/name/",
-		AddressableList:              "addressable",
+		Port:		"48081",
+		Host:		"localhost",
+		Protocol:	"http",
 	},
 	DataService: DataService{
-		Port:                       "48080",
-		ReadingByIDRoute:           "reading/id/",
-		VDescriptorByIDRoute:       "valuedescriptor/id/",
-		VDescriptorByNameRoute:     "valuedescriptor/name/",
-		DeleteEventByDeviceIDRoute: "event/device/",
+		Port:		"48080",
+		Host:		"localhost",
+		Protocol:	"http",
 	},
 	ExportService: ExportService{
-		Port:                    "48071",
-		RegistrationByIDRoute:   "registration/",
-		RegistrationByNameRoute: "registration/name/",
+		Port:		"48071",
+		Host:		"localhost",
+		Protocol:	"http",
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,16 @@ module github.com/edgexfoundry-holding/edgex-cli
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.3
+	github.com/edgexfoundry/go-mod-bootstrap v0.0.20
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.48
+	github.com/edgexfoundry/go-mod-registry v0.1.17
 	github.com/pelletier/go-toml v1.2.0
 	github.com/spf13/afero v1.1.2
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.3.2
+	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.3.0
-	github.com/ugorji/go v1.1.7
-	gopkg.in/yaml.v2 v2.2.7
+	github.com/ugorji/go v1.1.7 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/pkg/urlclient/factory.go
+++ b/pkg/urlclient/factory.go
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// urlclient provides functions to integrate the client code in go-mod-core-contracts with application specific code
+package urlclient
+
+import (
+	"context"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+)
+
+// New is a factory function that uses parameters defined in edgex-go to decide which implementation of URLClient to use
+func New(
+	ctx context.Context,
+	serviceKey string,
+	route string,
+	interval int,
+	url string) interfaces.URLClient {
+
+	return local.New(url)
+}


### PR DESCRIPTION
Started using the go-mod-core-contract clients instead of implementing the rest calls from scratch.

Note:
* Some of the clients are not implemented in go-mod-core-contract. (Addressable list, ds list/rm, ...)
* Not using the registry at this point (future work)


Signed-off-by: Alex Courouble <acourouble@vmware.com>