### PR TITLE
Define GOPATH and GOBIN when undefined within module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,20 @@
 
 GO = CGO_ENABLED=0 GO111MODULE=on go
 
+# Base go inside of module, to avoid collisions with other projects.
+ifndef $(GOPATH)
+  	GOMOD=$(shell go env GOMOD)
+  GOPATH=$(dir ${GOMOD})go
+  export GOPATH
+endif
+
+ifndef $(GOBIN)
+  	GOBIN=$(GOPATH)/bin
+  export GOBIN
+endif
+
+
+
 BINARY=edgex-cli
 
 VERSION=$(shell cat ./VERSION)
@@ -13,6 +27,7 @@ build:
 test:
 	$(GO) test ./... -coverprofile coverage.out
 install:
+	echo "GOBIN=$(GOBIN)"
 	$(GO) install $(GOFLAGS)
 
 clean:


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry-holding/edgex-cli/issues/118