### PR TITLE
Add required `-f` flag in `device add` command

### DIFF
--- a/cmd/device/add/add.go
+++ b/cmd/device/add/add.go
@@ -7,15 +7,17 @@ package add
 import (
 	"context"
 	"fmt"
-	"github.com/edgexfoundry-holding/edgex-cli/config"
-	"github.com/edgexfoundry-holding/edgex-cli/pkg/urlclient"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"io/ioutil"
 	"time"
 
-	"github.com/BurntSushi/toml"
+	"github.com/edgexfoundry-holding/edgex-cli/config"
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/urlclient"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/metadata"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/BurntSushi/toml"
 	"github.com/spf13/cobra"
 )
 
@@ -35,18 +37,18 @@ type DeviceFile struct {
 }
 
 func NewCommand() *cobra.Command {
+	var file string
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add devices",
-		Long:  `Create the devices described in the given TOML files.`,
+		Long:  `Create the devices described in the given TOML file.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("Add Devices:")
-			for _, val := range args {
-				fmt.Println(val, "... ")
-				processFile(val)
-			}
+			fname := cmd.Flag("file").Value.String()
+			processFile(fname)
 		},
 	}
+	cmd.Flags().StringVarP(&file, "file", "f", "", "Toml file containing device(s) configuration (required)")
+	cmd.MarkFlagRequired("file")
 	return cmd
 }
 
@@ -64,10 +66,9 @@ func addDevice(dev models.Device) (string, error) {
 			clients.CoreMetaDataServiceKey,
 			clients.ApiDeviceRoute,
 			15000,
-			url +  clients.ApiDeviceRoute,
+			url+clients.ApiDeviceRoute,
 		),
 	)
-
 
 	resp, err := mdc.Add(ctx, &dev)
 	if err != nil {
@@ -80,25 +81,25 @@ func addDevice(dev models.Device) (string, error) {
 func processFile(fname string) {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Println("...Invalid TOML")
+			fmt.Println("Invalid TOML")
 		}
 	}()
 
 	var content = &DeviceFile{}
 	file, err := ioutil.ReadFile(fname)
 	if err != nil {
-		fmt.Println("...Error loading file: ", err.Error())
+		fmt.Println("Error: ", err.Error())
 		return
 	}
 
 	err = toml.Unmarshal(file, content)
 	if err != nil {
-		fmt.Println("...Error parsing file: ", err.Error())
+		fmt.Println("Error: ", err.Error())
 		return
 	}
 
 	for _, d := range content.DeviceList {
-		fmt.Println("...Create device ", d.Name)
+		fmt.Println("Creating device: ", d.Name)
 		millis := time.Now().UnixNano() / int64(time.Millisecond)
 		dev := models.Device{
 			Name:           d.Name,
@@ -113,9 +114,9 @@ func processFile(fname string) {
 		dev.Origin = millis
 		id, err := addDevice(dev)
 		if err != nil {
-			fmt.Println("......Error: ", err.Error())
+			fmt.Println("Error: ", err.Error())
 		} else {
-			fmt.Println("......Created with ID ", id)
+			fmt.Println("Created with ID: ", id)
 		}
 	}
 }


### PR DESCRIPTION
'device add' command looks like this:
./edgex-cli device add --file /path/createDevice.toml
Flag --file/-f is required
Changed imports ordering, used: goimports, gofmt

Fixes: https://github.com/edgexfoundry-holding/edgex-cli/issues/143

Signed-off-by: Diana Atanasova <dianaa@vmware.com>