### PR TITLE
Fix error formatting when configuration files fail to parse

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -63,6 +63,6 @@ func LoadConfig() {
 	}
 
 	if _, err := toml.DecodeFile(configFile, &Conf); err != nil {
-		log.Fatal("Error occured while parsing %s:%s", configFile, err)
+		log.Fatalf("Error occured while parsing %s: %s", configFile, err)
 	}
 }


### PR DESCRIPTION
use log.Fatalf instead of log.Fatal

Fixes: https://github.com/edgexfoundry-holding/edgex-cli/issues/158

Signed-off-by: Diana Atanasova <dianaa@vmware.com>