### PR TITLE
Fix 405 error when delete all logs as part of `db purge` command

### DIFF
--- a/cmd/db/purge/purge.go
+++ b/cmd/db/purge/purge.go
@@ -118,7 +118,7 @@ func purge() {
 func removeLogs() {
 	fmt.Println("\n * Logs")
 	ts := time.Now().Unix() * 1000
-	url := config.Conf.Clients["Logging"].Url() + clients.ApiLoggingRoute + "/0" + strconv.FormatInt(ts, 10)
+	url := config.Conf.Clients["Logging"].Url() + clients.ApiLoggingRoute + "/0/" + strconv.FormatInt(ts, 10)
 	_, err := client.DeleteItem(url)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Fix: https://github.com/edgexfoundry-holding/edgex-cli/issues/172
Signed-off-by: Diana Atanasova <dianaa@vmware.com>