### PR TITLE
Change default Version value from "master" to "dev"

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "master"
+var Version = "dev"
 // NewCommand returns the version command
 func NewCommand() *cobra.Command {
 	var cmd = &cobra.Command{


### PR DESCRIPTION
Fix: https://github.com/edgexfoundry-holding/edgex-cli/issues/180

Signed-off-by: Diana Atanasova <dianaa@vmware.com>