### PR TITLE
PUT intervals: use go-mod-core-contracts interface client

### DIFF
--- a/cmd/interval/add/add.go
+++ b/cmd/interval/add/add.go
@@ -47,6 +47,7 @@ func addIntervalHandler(cmd *cobra.Command, args []string) {
 		intervals, err := parseToml(fname)
 		if err != nil {
 			fmt.Println("Error occur: ", err.Error())
+			continue
 		}
 		for _, i := range intervals {
 			request.Post(config.Conf.Clients["Scheduler"].Url()+clients.ApiIntervalRoute, &i)

--- a/cmd/notification/add/add.go
+++ b/cmd/notification/add/add.go
@@ -47,6 +47,7 @@ func addNotificationHandler(cmd *cobra.Command, args []string) {
 		notifications, err := parseToml(fname)
 		if err != nil {
 			fmt.Println("Error occur: ", err.Error())
+			continue
 		}
 		for _, n := range notifications {
 			request.Post(config.Conf.Clients["Notification"].Url()+clients.ApiNotificationRoute, &n)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/edgexfoundry-holding/edgex-cli
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.48
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pelletier/go-toml v1.2.0

--- a/samples/updateInterval.json
+++ b/samples/updateInterval.json
@@ -1,0 +1,16 @@
+{
+  "Intervals": [
+    {
+      "frequency": "P4D",
+      "name": "noon",
+      "origin": 0,
+      "start": "20180101T000000"
+    },
+    {
+      "frequency": "P4D",
+      "name": "fourteen-hundrend-hours",
+      "origin": 0,
+      "start": "20180101T000000"
+    }
+  ]
+}


### PR DESCRIPTION
It was not needed to add PUT function in requests.go file, because
of existance of Interval interface.
Start using JSon file as a source :)

Fix: https://github.com/edgexfoundry-holding/edgex-cli/issues/178

Signed-off-by: Diana Atanasova <dianaa@vmware.com>