### PR TITLE
Fix Helper msg in "device list" command

### DIFF
--- a/cmd/device/list/list.go
+++ b/cmd/device/list/list.go
@@ -35,8 +35,8 @@ const deviceTempl = "Device ID\tDevice Name\tOperating State\tAdmin State\tDevic
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "A list of all device services",
-		Long:  `Return all device services sorted by id.`,
+		Short: "A list of all devices",
+		Long:  `Return all devices sorted by id.`,
 		RunE: listHandler,
 	}
 	return cmd


### PR DESCRIPTION
The message should be about devices, not about device services

Fix: https://github.com/edgexfoundry-holding/edgex-cli/issues/224
Signed-off-by: Diana Atanasova <dianaa@vmware.com>