### PR TITLE
[feat] add `reading count` command

### DIFF
--- a/cmd/reading/count/count.go
+++ b/cmd/reading/count/count.go
@@ -1,0 +1,41 @@
+package count
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgexfoundry-holding/edgex-cli/config"
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/formatters"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
+	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCommand returns the count reading command
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "count",
+		Short: "Returns the count of core-data readings",
+		Long:  `Return a count of the number of readings in core data.`,
+		Args:  cobra.MaximumNArgs(0),
+		RunE:  countHandler,
+	}
+	return cmd
+}
+
+func countHandler(cmd *cobra.Command, args []string) (err error) {
+	client := coredata.NewReadingClient(
+		local.New(config.Conf.Clients["CoreData"].Url() + clients.ApiReadingRoute),
+	)
+	count, err := client.ReadingCount(context.Background())
+	if err != nil {
+		return
+	}
+
+	formatter := formatters.NewFormatter(fmt.Sprintf("Total readings count: %v", count), nil)
+	err = formatter.Write(count)
+	return
+}

--- a/cmd/reading/reading.go
+++ b/cmd/reading/reading.go
@@ -15,12 +15,13 @@
 package reading
 
 import (
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/reading/count"
 	listevent "github.com/edgexfoundry-holding/edgex-cli/cmd/reading/list"
 
 	"github.com/spf13/cobra"
 )
 
-// NewCommand returns the device command of type cobra.Command
+// NewCommand returns the reading commands of type cobra.Command
 func NewCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "reading",
@@ -28,5 +29,6 @@ func NewCommand() *cobra.Command {
 		Long:  `Actions related to device-generated readings.`,
 	}
 	cmd.AddCommand(listevent.NewCommand())
+	cmd.AddCommand(count.NewCommand())
 	return cmd
 }


### PR DESCRIPTION
./edgex-cli reading count -> return number of readings in core-data

Partially fix: https://github.com/edgexfoundry-holding/edgex-cli/issues/227

Signed-off-by: Diana Atanasova <dianaa@vmware.com>