### PR TITLE
[fix]Use "more" as default pager (fix windows problem)

### DIFF
--- a/pkg/pager/pager.go
+++ b/pkg/pager/pager.go
@@ -32,11 +32,11 @@ type Writer struct {
 }
 
 // getPagerCommand inspects the PAGER environment variable for a pager command,
-// otherwise returns a reasonable default ("less -FRX")
+// otherwise returns a reasonable default ("more)
 func getPagerCommand() (string, []string) {
 	fromEnv := os.Getenv("PAGER")
 	if fromEnv == "" {
-		return "less", []string{"-FRX"}
+		return "more", nil
 	}
 
 	split := strings.Split(fromEnv, " ")


### PR DESCRIPTION
Use "more" instead of "less" as default pager

Fixes: https://github.com/edgexfoundry-holding/edgex-cli/issues/127

Signed-off-by: Diana Atanasova <dianaa@vmware.com>