### PR TITLE
[refactor:db purge] Remove unnecessary requests for delete all readings

### DIFF
--- a/pkg/cmd/purge/coredata.go
+++ b/pkg/cmd/purge/coredata.go
@@ -10,9 +10,6 @@ import (
 
 type CoreDataCleaner interface {
 	Purge()
-	cleanEvents()
-	cleanReadings()
-	cleanValueDescriptors()
 }
 
 type coredataCleaner struct {
@@ -27,29 +24,8 @@ func NewCoredataCleaner() CoreDataCleaner {
 	}
 }
 func (d *coredataCleaner) Purge() {
-	d.cleanEvents()
-	d.cleanReadings()
+	d.cleanEventsAndReadings()
 	d.cleanValueDescriptors()
-}
-
-func (d *coredataCleaner) cleanReadings() {
-	url := d.baseUrl + clients.ApiReadingRoute
-	var readings []models.Reading
-	err := request.Get(url, readings)
-	if err != nil {
-		fmt.Printf("Error: %s\n", err.Error())
-		return
-	}
-
-	var count int
-	for _, reading := range readings {
-		// call delete function here
-		err = request.Delete(url + config.PathId + reading.Id)
-		if err == nil {
-			count = count + 1
-		}
-	}
-	fmt.Printf("Removed %d Readings from %d \n", count, len(readings))
 }
 
 func (d *coredataCleaner) cleanValueDescriptors() {
@@ -71,10 +47,10 @@ func (d *coredataCleaner) cleanValueDescriptors() {
 	fmt.Printf("Removed %d Value Descriptors from %d \n", count, len(valueDescriptors))
 }
 
-func (d *coredataCleaner) cleanEvents() {
+func (d *coredataCleaner) cleanEventsAndReadings() {
 	url := d.baseUrl + clients.ApiEventRoute + "/scruball"
 	err := request.Delete(url)
 	if err == nil {
-		fmt.Print("All Events have been removed \n")
+		fmt.Print("All Events and Readings have been removed \n")
 	}
 }

--- a/pkg/cmd/purge/metadata.go
+++ b/pkg/cmd/purge/metadata.go
@@ -15,10 +15,6 @@ import (
 
 type MetadataCleaner interface {
 	Purge()
-	cleanDevices()
-	cleanDeviceServices()
-	cleanDeviceProfiles()
-	cleanAddressables()
 }
 
 type metadataCleaner struct {

--- a/pkg/cmd/purge/scheduler.go
+++ b/pkg/cmd/purge/scheduler.go
@@ -10,8 +10,6 @@ import (
 
 type SchedulerCleaner interface {
 	Purge()
-	cleanIntervals()
-	cleanIntervalActions()
 }
 
 type schedulerCleaner struct {


### PR DESCRIPTION
- api/v1./events/scruball - removes all events and readings
That is why there is not need to execute other request that tries to delete readings
- Cleanup Cleaners interfaces

Signed-off-by: Diana Atanasova <dianaa@vmware.com>