### PR TITLE
[feat][event] New command added: `scrub` --all

### DIFF
--- a/cmd/event/count/count.go
+++ b/cmd/event/count/count.go
@@ -10,7 +10,7 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/coredata"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/urlclient/local"
-	
+
 	"github.com/spf13/cobra"
 )
 
@@ -40,11 +40,10 @@ func countHandler(cmd *cobra.Command, args []string) (err error) {
 		countNumber, err = client.EventCount(context.Background())
 		template = fmt.Sprintf("Total events count: %v", countNumber)
 	}
-	if err != nil{
+	if err != nil {
 		return err
 	}
 	formatter := formatters.NewFormatter(template, nil)
 	err = formatter.Write(countNumber)
 	return
 }
-

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -19,6 +19,7 @@ import (
 	"github.com/edgexfoundry-holding/edgex-cli/cmd/event/count"
 	listevent "github.com/edgexfoundry-holding/edgex-cli/cmd/event/list"
 	rmevent "github.com/edgexfoundry-holding/edgex-cli/cmd/event/rm"
+	"github.com/edgexfoundry-holding/edgex-cli/cmd/event/scrub"
 
 	"github.com/spf13/cobra"
 )
@@ -34,5 +35,6 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(addevent.NewCommand())
 	cmd.AddCommand(listevent.NewCommand())
 	cmd.AddCommand(count.NewCommand())
+	cmd.AddCommand(scrub.NewCommand())
 	return cmd
 }

--- a/cmd/event/rm/rm.go
+++ b/cmd/event/rm/rm.go
@@ -70,13 +70,12 @@ func validate(args []string) error {
 	return nil
 }
 
-
 func deleteByIds(dc coredata.EventClient, eventIds []string) error {
 	for _, eventId := range eventIds {
 		err := dc.Delete(context.Background(), eventId)
-		if err == nil{
+		if err == nil {
 			fmt.Printf("Event with id %s removed\n", eventId)
-		}else{
+		} else {
 			fmt.Printf("Error: %s \n", err)
 		}
 	}

--- a/cmd/event/scrub/scrub.go
+++ b/cmd/event/scrub/scrub.go
@@ -1,0 +1,50 @@
+package scrub
+
+import (
+	"github.com/edgexfoundry-holding/edgex-cli/config"
+	request "github.com/edgexfoundry-holding/edgex-cli/pkg"
+	"github.com/edgexfoundry-holding/edgex-cli/pkg/confirmation"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/clients"
+
+	"github.com/spf13/cobra"
+)
+
+var all bool
+
+// NewCommand return scrub events command
+func NewCommand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "scrub",
+		Short: "Remove all (pushed) events and their associated readings [USE WITH CAUTION]",
+		Long: `[USE WITH CAUTION] The effect of this command is irreversible. 
+It removes all pushed events and their associated.
+When used with "--all" flag, it removes all readings and events from the database`,
+		RunE: scrubHandler,
+	}
+	cmd.Flags().BoolP("all", "a", false, "Removes all readings and events from the database [USE WITH CAUTION]")
+	return cmd
+}
+
+func scrubHandler(cmd *cobra.Command, args []string) (err error) {
+	// asking user to confirm the scrub command
+	if !confirmation.New().Confirm() {
+		return
+	}
+	all, err1 := cmd.Flags().GetBool("all")
+	if err1 != nil {
+		return err1
+	}
+
+	url := config.Conf.Clients["CoreData"].Url() + clients.ApiEventRoute + "/scrub"
+	if all {
+		url = config.Conf.Clients["CoreData"].Url() + clients.ApiEventRoute + "/scruball"
+	}
+
+	err = request.Delete(url)
+	if err != nil {
+		return err
+	}
+
+	return
+}

--- a/pkg/confirmation/confirm.go
+++ b/pkg/confirmation/confirm.go
@@ -1,0 +1,74 @@
+package confirmation
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+const defaultConfirmMsg = "Are you sure? This cannot be undone: [y/n]"
+const defaultAbortMsg = "Aborting"
+
+type UserConfirmation struct {
+	confirmMsg string
+	abortMsg   string
+}
+
+//UserConfirmation creates new UserConfirmation using default values for confirmMsg and abortMsg
+func New() UserConfirmation {
+	return UserConfirmation{
+		confirmMsg: defaultConfirmMsg,
+		abortMsg:   defaultAbortMsg,
+	}
+}
+
+//NewCustom creates new UserConfirmation using custom confirmMsg and abortMsg
+func NewCustom(confirm, abort string) UserConfirmation {
+	confirmMsg := defaultConfirmMsg
+	if confirm != "" {
+		confirmMsg = confirm
+	}
+
+	abortMsg := defaultAbortMsg
+	if abort != "" {
+		abortMsg = abort
+	}
+	return UserConfirmation{
+		confirmMsg: confirmMsg,
+		abortMsg:   abortMsg,
+	}
+}
+// askForConfirmation uses Scanln to parse user input. A user must type in "yes" or "no" and
+// then press enter. It has fuzzy matching, so "y", "Y", "yes", "YES", and "Yes" all count as
+// confirmations. If the input is not recognized, it will ask again. The function does not return
+// until it gets a valid response from the user. Typically, you should use fmt to print out a question
+// before calling askForConfirmation. E.g. fmt.Println("WARNING: Are you sure? (yes/no)")
+func askForConfirmation() bool {
+	var response string
+
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	switch strings.ToLower(response) {
+	case "y", "yes":
+		return true
+	case "n", "no":
+		return false
+	default:
+		fmt.Println("I'm sorry but I didn't get what you meant, please type (y)es or (n)o and then press enter:")
+		return askForConfirmation()
+	}
+}
+
+//Ask user to confirm the execution
+func (c UserConfirmation) Confirm() bool{
+	fmt.Println(c.confirmMsg)
+	if !askForConfirmation() {
+		fmt.Println(c.abortMsg)
+		return false
+	}
+	return true
+}
+


### PR DESCRIPTION
Add "event scrub" command - that removes all pushed events and associated readings
Add "event scrub --all" command  - scrubs all events and readings from the database
Because both commands could deletes a lot of data -> user is asked for confirmation prior executing the command 

User confirmation logic is refactored
execute gofmt  

Partially fix: https://github.com/edgexfoundry-holding/edgex-cli/issues/226
Signed-off-by: Diana Atanasova <dianaa@vmware.com>